### PR TITLE
Added Error Checks for Division by Zero

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1730486359910</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,11 +3,22 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
         long result = ((long) a) / ((long) b);
         return result;
     }
 
     public static final long divisionUsingLoop(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
+
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -22,6 +33,12 @@ public class Division {
     }
 
     public static final long divisionUsingRecursion(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
+
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -38,6 +55,12 @@ public class Division {
     }
 
     public static final long divisionUsingMultiplication(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
+
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -55,6 +78,12 @@ public class Division {
     }
 
     public static final long divisionUsingShift(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
+
         int absA = Math.abs(a);
         int absB = Math.abs(b);
         int tempA, tempB, counter;
@@ -76,6 +105,12 @@ public class Division {
     }
 
     public static final long divisionUsingLogs(int a, int b) {
+        //Quiz Two 
+        //Cannot divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor must be non-zero");
+        }
+        
         long absA = Math.abs(a);
         long absB = Math.abs(b);
         double logBase10A = Math.log10(absA);


### PR DESCRIPTION
The following code:
        
 ` 
        if (b == 0) {
            throw new IllegalArgumentException("Divisor must be non-zero");
        }
`

Has been added to Division.java under the package com.jwetherell.algorithms.mathematics; This is to ensure that division by zero throws an illegal argument exception and reduce vulnerabilities in the code.